### PR TITLE
Feature/jody/primary window

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -1,8 +1,9 @@
 #include <iostream>
+#include <engine.hpp>
 
 int main()
 {
-	std::cout << "Running...";
+	engine::Engine engine;
 
-	return 0;
+	engine.init();
 }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,15 +1,17 @@
 # Engine CMake Lists
 
 # Used mark this as a static library
-add_library(engine STATIC src/engine.cpp "src/window/window.cpp")
+add_library(engine STATIC)
 
 target_include_directories(engine PRIVATE include)
 
 # Additional CMake scripts, Add External Libraries 
 include(cmake/FetchGLFW.cmake)
 
+# Glad files
+add_subdirectory(external)
+
 add_subdirectory(src)
 
-# TODO: Add A Folder for each of the External Libs.
-
-target_link_libraries(engine PRIVATE glfw) # Might need to be Pulic if the editor includes headers from engine.
+# glfw files
+target_link_libraries(engine PRIVATE glad glfw) # Might need to be Pulic if the editor includes headers from engine.

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Engine CMake Lists
 
 # Used mark this as a static library
-add_library(engine STATIC src/engine.cpp)
+add_library(engine STATIC src/engine.cpp "src/window/window.cpp")
 
 target_include_directories(engine PRIVATE include)
 

--- a/engine/external/CMakeLists.txt
+++ b/engine/external/CMakeLists.txt
@@ -4,9 +4,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_library(
   glad STATIC
-  src/glad.c
-  include/glad/glad.h
-  include/KHR/khrplatform.h
+  glad/src/glad.c
+  glad/include/glad/glad.h
+  glad/include/KHR/khrplatform.h
 )
 
-target_include_directories(glad PUBLIC include)
+target_include_directories(glad PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/glad/include)

--- a/engine/include/engine.hpp
+++ b/engine/include/engine.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace engine
+{
+	class Engine
+	{
+	public:
+		/**
+		* Used to initialize the engine
+		**/
+		void init();
+
+		/**
+		* Start the engine and its main loop
+		**/
+		void start();
+	};
+}

--- a/engine/include/engine.hpp
+++ b/engine/include/engine.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "window/window.hpp"
+
 namespace engine
 {
 	class Engine
@@ -14,5 +16,8 @@ namespace engine
 		* Start the engine and its main loop
 		**/
 		void start();
+
+	private:
+		Window window;
 	};
 }

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <glad/glad.h>
-#include <GLFW/glfw3.h>
-
 namespace engine
 {
 	class Window

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <iostream>
 
 namespace engine
 {

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -5,7 +5,7 @@
 
 namespace engine
 {
-	class Window()
+	class Window
 	{
 	public:
 		/**
@@ -13,5 +13,5 @@ namespace engine
 		**/
 		void init();
 
-	}
+	};
 }

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+namespace engine
+{
+	class Window()
+	{
+	public:
+		/**
+		* Initialize a GLFW window
+		**/
+		void init();
+
+	}
+}

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -11,5 +11,9 @@ namespace engine
 		**/
 		void init();
 
+	private:
+		// Settings
+		const int m_screen_width = 800;
+		const int m_screen_height = 600;
 	};
 }

--- a/engine/src/CMakeLists.txt
+++ b/engine/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Target Sources files
+# Target Sources files: Engine source files
 target_sources(engine PRIVATE 
 	"engine.cpp" 
 	"window/window.cpp")

--- a/engine/src/CMakeLists.txt
+++ b/engine/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 # Target Sources files
 target_sources(engine PRIVATE 
-	"engine.cpp")
+	"engine.cpp" 
+	"window/window.cpp")

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -1,8 +1,11 @@
-#include <iostream>
+#include "engine.hpp"
 
-int main()
+void engine::Engine::init()
 {
-	std::cout << "Build Succeeded, Print happened.";
 
-	return 0;
+}
+
+void engine::Engine::start()
+{
+
 }

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -2,6 +2,7 @@
 
 void engine::Engine::init()
 {
+	window.init();
 
 }
 

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -49,6 +49,10 @@ void engine::Window::init()
 		// Input
 		process_input(window);
 
+		// Rendering
+		glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT);
+
 		glfwSwapBuffers(window);
 		glfwPollEvents();
 	}

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -5,7 +5,7 @@
 
 // Forward Declare
 void framebuffer_size_callback(GLFWwindow* window, int width, int height);
-
+void process_input(GLFWwindow* window);
 
 void engine::Window::init()
 {
@@ -46,6 +46,9 @@ void engine::Window::init()
 	// Render Loop
 	while (!glfwWindowShouldClose(window))
 	{
+		// Input
+		process_input(window);
+
 		glfwSwapBuffers(window);
 		glfwPollEvents();
 	}
@@ -63,4 +66,12 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
 	glViewport(0, 0, width, height);
 	std::cout << "\n\n --- Window resized ---\n\n";
+}
+
+void process_input(GLFWwindow* window)
+{
+	if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+	{
+		glfwSetWindowShouldClose(window, true);
+	}
 }

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -1,0 +1,6 @@
+#include "window/window.hpp"
+
+void engine::Window::init()
+{
+	// Initialize GLFW window
+}

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -6,8 +6,46 @@
 
 void engine::Window::init()
 {
+	// Initialize the window attributes
 	glfwInit();
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+
+	// TODO: Place in the header at a later stage
+	int m_width = 800;
+	int m_height = 600;
+
+
+	GLFWwindow* window = glfwCreateWindow(m_width, m_height, "Fluid Solver", NULL, NULL);
+
+	// Crash if the window is null
+	if (window == NULL)
+	{
+		std::cout << "Failed to create GLFW window\n";
+		glfwTerminate();
+		//return -1;
+
+	}
+
+	glfwMakeContextCurrent(window);
+
+
+	// Pass GLAD the function to load the address of the OpenGL function pointer which is OS Specific.
+	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
+	{
+		std::cout << "Fail to Initialize GLAD\n";
+		// return -1;
+	}
+
+	// Viewport
+	glViewport(0, 0, m_width, m_height);
+
+	// Render Loop
+	while (!glfwWindowShouldClose(window))
+	{
+		glfwSwapBuffers(window);
+		glfwPollEvents();
+	}
 }

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -1,6 +1,13 @@
 #include "window/window.hpp"
 
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+
 void engine::Window::init()
 {
-	// Initialize GLFW window
+	glfwInit();
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
+	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 }

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -4,6 +4,16 @@
 #include <GLFW/glfw3.h>
 
 
+// GLFW Events
+/**
+* Called when resetting a windows size
+**/
+void framebuffer_size_callback(GLFWwindow* window, int width, int height)
+{
+	glViewport(0, 0, width, height);
+	std::cout << "\n\n --- Window resized ---\n\n";
+}
+
 void engine::Window::init()
 {
 	// Initialize the window attributes
@@ -42,10 +52,17 @@ void engine::Window::init()
 	// Viewport
 	glViewport(0, 0, m_width, m_height);
 
+	// Event callbacks
+	glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
+
 	// Render Loop
 	while (!glfwWindowShouldClose(window))
 	{
 		glfwSwapBuffers(window);
 		glfwPollEvents();
 	}
+
+	// End
+	glfwTerminate();
+	// return 0;
 }

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -3,16 +3,9 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
+// Forward Declare
+void framebuffer_size_callback(GLFWwindow* window, int width, int height);
 
-// GLFW Events
-/**
-* Called when resetting a windows size
-**/
-void framebuffer_size_callback(GLFWwindow* window, int width, int height)
-{
-	glViewport(0, 0, width, height);
-	std::cout << "\n\n --- Window resized ---\n\n";
-}
 
 void engine::Window::init()
 {
@@ -23,12 +16,7 @@ void engine::Window::init()
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 
-	// TODO: Place in the header at a later stage
-	int m_width = 800;
-	int m_height = 600;
-
-
-	GLFWwindow* window = glfwCreateWindow(m_width, m_height, "Fluid Solver", NULL, NULL);
+	GLFWwindow* window = glfwCreateWindow(m_screen_width, m_screen_height, "Fluid Solver", NULL, NULL);
 
 	// Crash if the window is null
 	if (window == NULL)
@@ -50,7 +38,7 @@ void engine::Window::init()
 	}
 
 	// Viewport
-	glViewport(0, 0, m_width, m_height);
+	glViewport(0, 0, m_screen_width, m_screen_height);
 
 	// Event callbacks
 	glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
@@ -65,4 +53,14 @@ void engine::Window::init()
 	// End
 	glfwTerminate();
 	// return 0;
+}
+
+// GLFW Events
+/**
+* Called when resetting a windows size
+**/
+void framebuffer_size_callback(GLFWwindow* window, int width, int height)
+{
+	glViewport(0, 0, width, height);
+	std::cout << "\n\n --- Window resized ---\n\n";
 }

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -8,6 +8,6 @@ void engine::Window::init()
 {
 	glfwInit();
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 }


### PR DESCRIPTION
# Description
Setup a basic window Header and Source file to deal with the main window.
For now, the `window.cpp` file is doing everything including the main render loop which will need to get changed in an upcoming PR to move to the `engine.cpp` file.

# Info
## Setup engine structure
- Adding a Namespace: `engine`
- Adding a class: `Engine`
- Adding the base functions `init()` and `start()` with simple docstrings for now
- Adding base function structure

## Editor updates
- Adding an `engine` object and calling the `engine.init()` function

## Adding window file
- Adding a new directory window under `engine/src/`
- Added a new source file window.cpp under `engine/src/window/`
- Updating `add_library() to include `window.cpp` under `engine/CMakeLists.txt`
- Updating  `target_sources()` to include window.cpp under `engine/src/CMakeLists.txt`
- Adding `window.hpp` under `engine/incclude/window/`

## Updating CMake files
- Updating the `engine/src/CMakeLists.txt` comment for more clarity as to what it's for
- Updated `external/CMakeLists.txt` by adding `glad/` to the `add_library()`
- Updated `external/CMakeLists.txt` with an updated path in `target_include_directories()`
- Updated `engine/CMakeLists.txt` with `add_subdirectory(external)` to link to `glad`

## Window Work
- Added the base class structure for the header file: `window.hpp` with the `init()` function
- Working on getting a rough window to display so testing can start
- Basic setup of the `GLFW` windowing system in `widnow.cpp`
- Updated `engine/CMakeLists.txt`and included `glad` in the `target_link_libraries()`
- Implemented the window resizing callback function
- Did some code cleanup for a better read
- Implemented a close event key press
- Simple rendering command for clearing the colour buffer