### PR TITLE
Exersise::Draw two triangles with two VBOs and VAOs

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -5,5 +5,5 @@ int main()
 {
 	engine::Engine engine;
 
-	engine.init();
+	engine.start();
 }

--- a/engine/include/engine.hpp
+++ b/engine/include/engine.hpp
@@ -15,9 +15,11 @@ namespace engine
 		/**
 		* Start the engine and its main loop
 		**/
-		void start();
+		int start();
 
 	private:
-		Window window;
+		engine::Window m_engine_window;
+
+		GLFWwindow* m_window;
 	};
 }

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -1,19 +1,44 @@
 #pragma once
 #include <iostream>
 
+struct GLFWwindow;
+
 namespace engine
 {
 	class Window
 	{
 	public:
+		Window();
+		~Window();
+
 		/**
 		* Initialize a GLFW window
 		**/
 		void init();
 
+		/**
+		* Used to return the window object from GLFW
+		**/
+		GLFWwindow* getGLFWwindow() const;
+
+		// --- GLWF Events ---
+
+		/**
+		* called when the window is resized and sets the glViewport to the current window size
+		**/
+		void framebuffer_size_callback(GLFWwindow* window, int width, int height);
+
+		/**
+		* Used for Input processing like Keyboard, Mouse or controller
+		**/
+		void process_input(GLFWwindow* window);
+
 	private:
 		// Settings
 		const int m_screen_width = 800;
 		const int m_screen_height = 600;
+
+		GLFWwindow* m_window;
+
 	};
 }

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -25,13 +25,14 @@ namespace engine
 
 		/**
 		* called when the window is resized and sets the glViewport to the current window size
+		* @NOTE: Made static as GLFW requires callback functions to have a C-style function signature (
 		**/
-		void framebuffer_size_callback(GLFWwindow* window, int width, int height);
+		static void framebuffer_size_callback(GLFWwindow* window, int width, int height);
 
 		/**
 		* Used for Input processing like Keyboard, Mouse or controller
 		**/
-		void process_input(GLFWwindow* window);
+		static void process_input(GLFWwindow* window);
 
 	private:
 		// Settings

--- a/engine/include/window/window.hpp
+++ b/engine/include/window/window.hpp
@@ -32,7 +32,7 @@ namespace engine
 		/**
 		* Used for Input processing like Keyboard, Mouse or controller
 		**/
-		static void process_input(GLFWwindow* window);
+		void process_input(GLFWwindow* window);
 
 	private:
 		// Settings

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -38,27 +38,44 @@ int engine::Engine::start()
 
 	// Build and Comile our Shader Program
 	// ------------------------------------------------
-	// Vertex Shader
-	unsigned int vertex_shader{};
 
 	// Checking if shader comiliation was successful
-	int shader_vertex_success{};
+	int success{};
 	char info_log[512];
 
 
+	// Vertex Shader
+	unsigned int vertex_shader{};
 	vertex_shader = glCreateShader(GL_VERTEX_SHADER);
 
 	glShaderSource(vertex_shader, 1, &vertex_shader_source, nullptr);
 	glCompileShader(vertex_shader);
 
-	// Check Compiliation success
-	glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &shader_vertex_success);
+	//Vertex Compiliation success
+	glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &success);
 
-	if (!shader_vertex_success)
+	if (!success)
 	{
 		glGetShaderInfoLog(vertex_shader, 512, nullptr, info_log);
-		std::cout << "ERROR::SHADER::VERTEX::COMPILE FAILED\n" << info_log << "\n";
+		std::cout << "ERROR::SHADER::VERTEX::COMPILE FAILED\n" << info_log << "\n\n";
 	}
+
+	// Fragment Shader
+	unsigned int fragment_shader{};
+	fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+
+	glShaderSource(fragment_shader, 1, &fragment_shader_source, nullptr);
+	glCompileShader(fragment_shader);
+
+	// Fragment Compilation success
+	glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &success);
+
+	if (!success)
+	{
+		glGetShaderInfoLog(fragment_shader, 512, nullptr, info_log);
+		std::cout << "ERROR::SHADER::FRAGMENT::COMPILED FAILED\n" << info_log << "\n\n";
+	}
+
 
 	// Vertex Data
 	float vertices[] =

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -126,20 +126,20 @@ int engine::Engine::start()
 	// Main loop
 	while (!glfwWindowShouldClose(m_window))
 	{
-		// Input
+		// Input handling
 		m_engine_window.process_input(m_window);
 
-		// Rendering
+		// Rendering: Clear the Back Buffer
 		glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 
 
-		// Draw Triangle
+		// Draw Triangle: On the Back Buffer
 		glUseProgram(shader_program);
 		glBindVertexArray(VAO);
 		glDrawArrays(GL_TRIANGLES, 0, 3);
 
-
+		// Swap the Front and Back Buffers
 		glfwSwapBuffers(m_window);
 		glfwPollEvents();
 	}

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -44,7 +44,7 @@ int engine::Engine::start()
 	char info_log[512];
 
 
-	// Vertex Shader
+	// --- Vertex Shader ---
 	unsigned int vertex_shader{};
 	vertex_shader = glCreateShader(GL_VERTEX_SHADER);
 
@@ -60,7 +60,7 @@ int engine::Engine::start()
 		std::cout << "ERROR::SHADER::VERTEX::COMPILE FAILED\n" << info_log << "\n\n";
 	}
 
-	// Fragment Shader
+	// --- Fragment Shader ---
 	unsigned int fragment_shader{};
 	fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
 
@@ -76,7 +76,7 @@ int engine::Engine::start()
 		std::cout << "ERROR::SHADER::FRAGMENT::COMPILED FAILED\n" << info_log << "\n\n";
 	}
 
-	// Shader Program
+	// --- Shader Program ---
 	unsigned int shader_program{};
 	shader_program = glCreateProgram();
 
@@ -97,7 +97,7 @@ int engine::Engine::start()
 	glDeleteShader(fragment_shader);
 
 
-	// Vertex Data
+	// --- Vertex Data ---
 	float vertices[] =
 	{
 		-0.5f, -0.5f, 0.0f,
@@ -106,12 +106,20 @@ int engine::Engine::start()
 	};
 
 	// Setup Vertex Buffer Object
-	unsigned int VBO{};
+	unsigned int VBO, VAO{};
+	glGenVertexArrays(1, &VAO);
 	glGenBuffers(1, &VBO);
+
+	// Bind Vertex Array first: Must do this first, then Bind and set vertex buffers, and then configure vertex attributes.
+	glBindVertexArray(VAO);
 
 	glBindBuffer(GL_ARRAY_BUFFER, VBO);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
+
+	// Vertex Attributes
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+	glEnableVertexAttribArray(0);
 
 	// ------------------------------------------------
 
@@ -126,8 +134,10 @@ int engine::Engine::start()
 		glClear(GL_COLOR_BUFFER_BIT);
 
 
+		// Draw Triangle
 		glUseProgram(shader_program);
-
+		glBindVertexArray(VAO);
+		glDrawArrays(GL_TRIANGLES, 0, 3);
 
 
 		glfwSwapBuffers(m_window);

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -19,6 +19,14 @@ int engine::Engine::start()
 		return -1;
 	}
 
+	// Build and Comile our Shader Program
+	// ------------------------------------------------
+
+
+
+	// ------------------------------------------------
+
+	// Main loop
 	while (!glfwWindowShouldClose(m_window))
 	{
 		// Input

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -14,6 +14,13 @@ const char* vertex_shader_source = "#version 330 core\n"
 "	gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0f);\n"
 "}\0";
 
+const char* fragment_shader_source = "#version 330 core\n"
+"out vec4 FragColor;\n"
+"void main()\n"
+"{\n"
+"	FragColor = vec4(1.0f, 0.5f, 0.2f, 1.0f);"
+"}\n";
+
 void engine::Engine::init()
 {
 }

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -118,25 +118,43 @@ int engine::Engine::start()
 	};
 
 	// Setup Vertex Buffer Object
-	unsigned int VBO{}, VAO{}, EBO{};
-	glGenVertexArrays(1, &VAO);
-	glGenBuffers(1, &VBO);
+	unsigned int VBOA{}, VBOB{}, VAOA{}, VAOB{}, EBO{};
+
+	// Buffer::A
+	glGenVertexArrays(1, &VAOA);
+	glGenBuffers(1, &VBOA);
+
+	glBindVertexArray(VAOA);
+
+	glBindBuffer(GL_ARRAY_BUFFER, VBOA);
+
+
+	// TODO: Check if two are needed ?
+	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+	glEnableVertexAttribArray(0); // TODO: Checck if needed, I have one at the Bottome already
+
+
+
+	// Buffer::B
+	glGenVertexArrays(1, &VAOB);
+	glGenBuffers(1, &VBOB);
 	//glGenBuffers(1, &EBO);
 
 	// Bind Vertex Array first: Must do this first, then Bind and set vertex buffers, and then configure vertex attributes.
-	glBindVertexArray(VAO);
+	glBindVertexArray(VAOB);
 
-	glBindBuffer(GL_ARRAY_BUFFER, VBO);
+	glBindBuffer(GL_ARRAY_BUFFER, VBOB);
+	// Element stuff..
 	//glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 	//glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 
-
 	// Vertex Attributes
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
-	//glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
-	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+	glEnableVertexAttribArray(1);
 
 	// Uncomment to render Wireframe
 	//glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
@@ -156,14 +174,16 @@ int engine::Engine::start()
 
 		// Draw Triangle: On the Back Buffer
 		glUseProgram(shader_program);
-		glBindVertexArray(VAO);
+		glBindVertexArray(VAOA);
+		glBindVertexArray(VAOB);
 
 		// Using the EBO to draw a rectangle
 		//glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 		//glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
 
 		// Moving to Element Buffer, No longer needed
-		glDrawArrays(GL_TRIANGLES, 0, 6);
+		glDrawArrays(GL_TRIANGLES, 0, 3);
+		glDrawArrays(GL_TRIANGLES, 3, 3); // TODO:Not sure if this is Needed ?
 
 		// Swap the Front and Back Buffers
 		glfwSwapBuffers(m_window);

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -100,9 +100,16 @@ int engine::Engine::start()
 	// --- Vertex Data ---
 	float vertices[] =
 	{
-		-0.5f, -0.5f, 0.0f,
-		0.5f, -0.5f, 0.0f,
-		0.0f, 0.5f, 0.0f
+		0.5f, 0.5f, 0.0f,   // top right
+		0.5f, -0.5f, 0.0f,  // bottom right
+		-0.5f, -0.5f, 0.0f, // bottom left
+		-0.5f, 0.5f, 0.0f   // top left
+	};
+
+	unsigned int indices[] =
+	{
+		0, 1, 3, // first triangle
+		1, 2, 3  // second triangle
 	};
 
 	// Setup Vertex Buffer Object

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -1,8 +1,9 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
-#include "engine.hpp"
+#include <array>
 
+#include "engine.hpp"
 
 void engine::Engine::init()
 {
@@ -21,8 +22,23 @@ int engine::Engine::start()
 
 	// Build and Comile our Shader Program
 	// ------------------------------------------------
+	// Vertex Shader
 
 
+	// Vertex Data
+	float vertices[] = 
+	{
+		-0.5f, -0.5f, 0.0f,
+		0.5f, -0.5f, 0.0f,
+		0.0f, 0.5f, 0.0f
+	};
+
+	// Setup Vertex Buffer Object
+	unsigned int VBO;
+	glGenBuffers(1, &VBO);
+
+	glBindBuffer(GL_ARRAY_BUFFER, VBO);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
 	// ------------------------------------------------
 

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -100,10 +100,15 @@ int engine::Engine::start()
 	// --- Vertex Data ---
 	float vertices[] =
 	{
-		0.5f, 0.5f, 0.0f,   // top right
-		0.5f, -0.5f, 0.0f,  // bottom right
-		-0.5f, -0.5f, 0.0f, // bottom left
-		-0.5f, 0.5f, 0.0f   // top left
+		// Triangel 1
+		-0.75f, 0.25f, 0.0f,		// top
+		-0.9f, -0.25f, 0.0f,		// Left
+		-0.6f, -0.25f, 0.0f,		// Right
+
+		// Triangle Two
+		0.75f, 0.25f, 0.0f,
+		0.6f, -0.25f, 0.0f,
+		0.9f, -0.25f, 0.0f
 	};
 
 	unsigned int indices[] =
@@ -116,20 +121,21 @@ int engine::Engine::start()
 	unsigned int VBO{}, VAO{}, EBO{};
 	glGenVertexArrays(1, &VAO);
 	glGenBuffers(1, &VBO);
-	glGenBuffers(1, &EBO);
+	//glGenBuffers(1, &EBO);
 
 	// Bind Vertex Array first: Must do this first, then Bind and set vertex buffers, and then configure vertex attributes.
 	glBindVertexArray(VAO);
 
 	glBindBuffer(GL_ARRAY_BUFFER, VBO);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+	//glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+	//glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 
 
 	// Vertex Attributes
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+	//glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 	glEnableVertexAttribArray(0);
 
 	// Uncomment to render Wireframe
@@ -153,11 +159,11 @@ int engine::Engine::start()
 		glBindVertexArray(VAO);
 
 		// Using the EBO to draw a rectangle
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
-		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+		//glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+		//glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
 
 		// Moving to Element Buffer, No longer needed
-		// glDrawArrays(GL_TRIANGLES, 0, 3);
+		glDrawArrays(GL_TRIANGLES, 0, 6);
 
 		// Swap the Front and Back Buffers
 		glfwSwapBuffers(m_window);

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -5,6 +5,15 @@
 
 #include "engine.hpp"
 
+
+// Temp Data for testing
+const char* vertex_shader_source = "# Version 330 core\n"
+"layout(location = 0) in vec3 aPos; \n"
+"oid main()\n"
+"{\n"
+"	gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0f);\n"
+"}\0";
+
 void engine::Engine::init()
 {
 }
@@ -23,10 +32,12 @@ int engine::Engine::start()
 	// Build and Comile our Shader Program
 	// ------------------------------------------------
 	// Vertex Shader
+	unsigned int vertex_shader{};
+	vertex_shader = glCreateShader(GL_VERTEX_SHADER);
 
 
 	// Vertex Data
-	float vertices[] = 
+	float vertices[] =
 	{
 		-0.5f, -0.5f, 0.0f,
 		0.5f, -0.5f, 0.0f,
@@ -34,7 +45,7 @@ int engine::Engine::start()
 	};
 
 	// Setup Vertex Buffer Object
-	unsigned int VBO;
+	unsigned int VBO{};
 	glGenBuffers(1, &VBO);
 
 	glBindBuffer(GL_ARRAY_BUFFER, VBO);

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -1,12 +1,16 @@
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
 #include "engine.hpp"
+
 
 void engine::Engine::init()
 {
 	window.init();
-
+	// TODO: Get back the window object
 }
 
 void engine::Engine::start()
 {
-
+	// TODO: Start the main loop
 }

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -6,11 +6,31 @@
 
 void engine::Engine::init()
 {
-	window.init();
-	// TODO: Get back the window object
 }
 
-void engine::Engine::start()
+int engine::Engine::start()
 {
-	// TODO: Start the main loop
+	m_engine_window.init();
+
+	m_window = m_engine_window.getGLFWwindow();
+
+	if (!m_window)
+	{
+		return -1;
+	}
+
+	while (!glfwWindowShouldClose(m_window))
+	{
+		// Input
+		m_engine_window.process_input(m_window);
+
+		// Rendering
+		glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT);
+
+		glfwSwapBuffers(m_window);
+		glfwPollEvents();
+	}
+
+	return 0;
 }

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -7,9 +7,9 @@
 
 
 // Temp Data for testing
-const char* vertex_shader_source = "# Version 330 core\n"
+const char* vertex_shader_source = "#version 330 core\n"
 "layout(location = 0) in vec3 aPos; \n"
-"oid main()\n"
+"void main()\n"
 "{\n"
 "	gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0f);\n"
 "}\0";
@@ -33,8 +33,25 @@ int engine::Engine::start()
 	// ------------------------------------------------
 	// Vertex Shader
 	unsigned int vertex_shader{};
+
+	// Checking if shader comiliation was successful
+	int shader_vertex_success{};
+	char info_log[512];
+
+
 	vertex_shader = glCreateShader(GL_VERTEX_SHADER);
 
+	glShaderSource(vertex_shader, 1, &vertex_shader_source, nullptr);
+	glCompileShader(vertex_shader);
+
+	// Check Compiliation success
+	glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &shader_vertex_success);
+
+	if (!shader_vertex_success)
+	{
+		glGetShaderInfoLog(vertex_shader, 512, nullptr, info_log);
+		std::cout << "ERROR::SHADER::VERTEX::COMPILE FAILED\n" << info_log << "\n";
+	}
 
 	// Vertex Data
 	float vertices[] =
@@ -50,6 +67,7 @@ int engine::Engine::start()
 
 	glBindBuffer(GL_ARRAY_BUFFER, VBO);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
 
 	// ------------------------------------------------
 

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -96,19 +96,35 @@ int engine::Engine::start()
 	glDeleteShader(vertex_shader);
 	glDeleteShader(fragment_shader);
 
-
 	// --- Vertex Data ---
 	float vertices[] =
 	{
-		// Triangel 1
+		// Triangle One
 		-0.75f, 0.25f, 0.0f,		// top
 		-0.9f, -0.25f, 0.0f,		// Left
 		-0.6f, -0.25f, 0.0f,		// Right
 
-		// Triangle Two
-		0.75f, 0.25f, 0.0f,
-		0.6f, -0.25f, 0.0f,
-		0.9f, -0.25f, 0.0f
+		// Triangle two
+		0.75f, 0.25f, 0.0f,		// top
+		0.6f, -0.25f, 0.0f,		// left
+		0.9f, -0.25f, 0.0f		// right
+	};
+
+
+	// --- Vertex Data ---
+	float first_triangle[] =
+	{
+		-0.75f, 0.25f, 0.0f,		// top
+		-0.9f, -0.25f, 0.0f,		// Left
+		-0.6f, -0.25f, 0.0f,		// Right
+	};
+
+	float second_triangle[] =
+	{
+		0.75f, 0.25f, 0.0f,		// top
+		0.6f, -0.25f, 0.0f,		// left
+		0.9f, -0.25f, 0.0f		// right
+
 	};
 
 	unsigned int indices[] =
@@ -118,50 +134,29 @@ int engine::Engine::start()
 	};
 
 	// Setup Vertex Buffer Object
-	unsigned int VBOA{}, VBOB{}, VAOA{}, VAOB{}, EBO{};
+	// (OLD) - unsigned int VBOA{}, VBOB{}, VAOA{}, VAOB{}, EBO{}; TODO: Remove
+	GLuint VBOs[2];
+	GLuint VAOs[2];
 
-	// Buffer::A
-	glGenVertexArrays(1, &VAOA);
-	glGenBuffers(1, &VBOA);
+	// Generate Buffers
+	glGenVertexArrays(2, VAOs);
+	glGenBuffers(2, VBOs);
 
-	glBindVertexArray(VAOA);
+	// Loop over the array
+	for (int i = 0; i < 2; i++)
+	{
+		glBindVertexArray(VAOs[i]);
+		glBindBuffer(GL_ARRAY_BUFFER, VBOs[i]);
 
-	glBindBuffer(GL_ARRAY_BUFFER, VBOA);
+		glBufferData(GL_ARRAY_BUFFER, sizeof(vertices) / 2, &vertices[i * 9], GL_STATIC_DRAW);
 
+		glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void*)0); // Because the data is Tightly packed, We can let OpenGL figure it out.
+		glEnableVertexAttribArray(0);
+	}
 
-	// TODO: Check if two are needed ?
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
-	glEnableVertexAttribArray(0); // TODO: Checck if needed, I have one at the Bottome already
-
-
-
-	// Buffer::B
-	glGenVertexArrays(1, &VAOB);
-	glGenBuffers(1, &VBOB);
-	//glGenBuffers(1, &EBO);
-
-	// Bind Vertex Array first: Must do this first, then Bind and set vertex buffers, and then configure vertex attributes.
-	glBindVertexArray(VAOB);
-
-	glBindBuffer(GL_ARRAY_BUFFER, VBOB);
-	// Element stuff..
-	//glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
-
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-	//glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
-
-	// Vertex Attributes
-	glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
-	glEnableVertexAttribArray(1);
-
-	// Uncomment to render Wireframe
-	//glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-
-	// ------------------------------------------------
 
 	// Main loop
+	// ---------
 	while (!glfwWindowShouldClose(m_window))
 	{
 		// Input handling
@@ -174,16 +169,13 @@ int engine::Engine::start()
 
 		// Draw Triangle: On the Back Buffer
 		glUseProgram(shader_program);
-		glBindVertexArray(VAOA);
-		glBindVertexArray(VAOB);
-
-		// Using the EBO to draw a rectangle
-		//glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
-		//glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+		for (int i = 0; i < 2; i++)
+		{
+			glBindVertexArray(VAOs[i]);
+			glDrawArrays(GL_TRIANGLES, 0, 3);
+		}
 
 		// Moving to Element Buffer, No longer needed
-		glDrawArrays(GL_TRIANGLES, 0, 3);
-		glDrawArrays(GL_TRIANGLES, 3, 3); // TODO:Not sure if this is Needed ?
 
 		// Swap the Front and Back Buffers
 		glfwSwapBuffers(m_window);

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -132,6 +132,9 @@ int engine::Engine::start()
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 	glEnableVertexAttribArray(0);
 
+	// Uncomment to render Wireframe
+	//glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+
 	// ------------------------------------------------
 
 	// Main loop
@@ -153,7 +156,7 @@ int engine::Engine::start()
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
 
-		// Moving to Element Buffer
+		// Moving to Element Buffer, No longer needed
 		// glDrawArrays(GL_TRIANGLES, 0, 3);
 
 		// Swap the Front and Back Buffers

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -113,15 +113,19 @@ int engine::Engine::start()
 	};
 
 	// Setup Vertex Buffer Object
-	unsigned int VBO, VAO{};
+	unsigned int VBO{}, VAO{}, EBO{};
 	glGenVertexArrays(1, &VAO);
 	glGenBuffers(1, &VBO);
+	glGenBuffers(1, &EBO);
 
 	// Bind Vertex Array first: Must do this first, then Bind and set vertex buffers, and then configure vertex attributes.
 	glBindVertexArray(VAO);
 
 	glBindBuffer(GL_ARRAY_BUFFER, VBO);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 
 
 	// Vertex Attributes
@@ -144,7 +148,13 @@ int engine::Engine::start()
 		// Draw Triangle: On the Back Buffer
 		glUseProgram(shader_program);
 		glBindVertexArray(VAO);
-		glDrawArrays(GL_TRIANGLES, 0, 3);
+
+		// Using the EBO to draw a rectangle
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+
+		// Moving to Element Buffer
+		// glDrawArrays(GL_TRIANGLES, 0, 3);
 
 		// Swap the Front and Back Buffers
 		glfwSwapBuffers(m_window);

--- a/engine/src/engine.cpp
+++ b/engine/src/engine.cpp
@@ -76,6 +76,26 @@ int engine::Engine::start()
 		std::cout << "ERROR::SHADER::FRAGMENT::COMPILED FAILED\n" << info_log << "\n\n";
 	}
 
+	// Shader Program
+	unsigned int shader_program{};
+	shader_program = glCreateProgram();
+
+	glAttachShader(shader_program, vertex_shader);
+	glAttachShader(shader_program, fragment_shader);
+	glLinkProgram(shader_program);
+
+	glGetProgramiv(shader_program, GL_LINK_STATUS, &success);
+
+	if (!success)
+	{
+		glGetProgramInfoLog(shader_program, 512, nullptr, info_log);
+		std::cout << "ERROR::SHADER::PROGRAM::COMPILE FAILED\n" << info_log << "\n\n";
+	}
+
+	// Cleanup Unneeded Shaders
+	glDeleteShader(vertex_shader);
+	glDeleteShader(fragment_shader);
+
 
 	// Vertex Data
 	float vertices[] =
@@ -104,6 +124,11 @@ int engine::Engine::start()
 		// Rendering
 		glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
+
+
+		glUseProgram(shader_program);
+
+
 
 		glfwSwapBuffers(m_window);
 		glfwPollEvents();

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -3,9 +3,14 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
-// Forward Declare
-void framebuffer_size_callback(GLFWwindow* window, int width, int height);
-void process_input(GLFWwindow* window);
+engine::Window::Window() : m_window(nullptr) {}
+
+engine::Window::~Window()
+{
+	glfwDestroyWindow(m_window);
+	glfwTerminate();
+}
+
 
 void engine::Window::init()
 {
@@ -14,65 +19,19 @@ void engine::Window::init()
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
-
-	GLFWwindow* window = glfwCreateWindow(m_screen_width, m_screen_height, "Fluid Solver", NULL, NULL);
-
-	// Crash if the window is null
-	if (window == NULL)
-	{
-		std::cout << "Failed to create GLFW window\n";
-		glfwTerminate();
-		//return -1;
-
-	}
-
-	glfwMakeContextCurrent(window);
-
-
-	// Pass GLAD the function to load the address of the OpenGL function pointer which is OS Specific.
-	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
-	{
-		std::cout << "Fail to Initialize GLAD\n";
-		// return -1;
-	}
-
-	// Viewport
-	glViewport(0, 0, m_screen_width, m_screen_height);
-
-	// Event callbacks
-	glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
-
-	// Render Loop
-	while (!glfwWindowShouldClose(window))
-	{
-		// Input
-		process_input(window);
-
-		// Rendering
-		glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
-		glClear(GL_COLOR_BUFFER_BIT);
-
-		glfwSwapBuffers(window);
-		glfwPollEvents();
-	}
-
-	// End
-	glfwTerminate();
-	// return 0;
 }
 
 // GLFW Events
 /**
 * Called when resetting a windows size
 **/
-void framebuffer_size_callback(GLFWwindow* window, int width, int height)
+void engine::Window::framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
 	glViewport(0, 0, width, height);
 	std::cout << "\n\n --- Window resized ---\n\n";
 }
 
-void process_input(GLFWwindow* window)
+void engine::Window::process_input(GLFWwindow* window)
 {
 	if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
 	{

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -48,10 +48,12 @@ void engine::Window::init()
 
 }
 
+GLFWwindow* engine::Window::getGLFWwindow() const
+{
+	return m_window;
+}
+
 // GLFW Events
-/**
-* Called when resetting a windows size
-**/
 void engine::Window::framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
 	glViewport(0, 0, width, height);

--- a/engine/src/window/window.cpp
+++ b/engine/src/window/window.cpp
@@ -19,6 +19,33 @@ void engine::Window::init()
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+	m_window = glfwCreateWindow(m_screen_width, m_screen_height, "Fluid Solver", nullptr, nullptr);
+
+	// Crash if the window is null
+	if (!m_window)
+	{
+		std::cout << "Failed to create GLFW window\n";
+		glfwTerminate();
+		return;
+	}
+
+	glfwMakeContextCurrent(m_window);
+
+
+	// Pass GLAD the function to load the address of the OpenGL function pointer which is OS Specific.
+	if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
+	{
+		std::cout << "Fail to Initialize GLAD\n";
+		return;
+	}
+
+	// Viewport
+	glViewport(0, 0, m_screen_width, m_screen_height);
+
+	// Event callbacks
+	glfwSetFramebufferSizeCallback(m_window, framebuffer_size_callback);
+
 }
 
 // GLFW Events


### PR DESCRIPTION
# Info
This PR has quite a lot going on. I Have created a Windowing system using `GLFW`, as well as Setting up the main structure of the project with the `Editor`, `Engine` and `Windowing` with a simple double triangle render using OpenGL

---
# Editor
_`header`_
- Removed `engine.init()` as this was redundant as it was not needed at this point
---
# Engine
_`Header`_
- Updated `start()` to return an `int`
- Added Variables for the `GLFWwindow` Object and a reference to the `window` class


_`Source`_
@Note: A lot of Commits have been pushed as I was learning OpenGL and committing change to the Triangle and Rectangle draw, I am going to note the final changes:
- Added a `Vertex` and `Fragment` Shader
- Adding the Main render loop
- Added logic to draw two triangles to screen using and array of `VBOs` and `VAOs`
- Adding a Shander Program to render the Triangles
---
# Windowing
_`Header`_
- Added support for `Input Processing` and `Window Resizing`

_`Source`_
- initialized the main window in GLFW and the Viewport area
- Added Support to get a `GLFWwindow` object from this `window` class
- Added Support for Window resizing with an even callback
- Added support for Input Handling - _(Current support is the Escape key only)_